### PR TITLE
Fix calculations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var UINT_32_MAX = 0xffffffff
+var TWOPOW32 = 0x100000000
 
 exports.encodingLength = function () {
   return 6
@@ -8,8 +8,8 @@ exports.encode = function (num, buf, offset) {
   if (!buf) buf = new Buffer(6)
   if (!offset) offset = 0
 
-  var top = Math.floor(num / (UINT_32_MAX + 1))
-  var rem = num - top * (UINT_32_MAX + 1)
+  var top = Math.floor(num / TWOPOW32)
+  var rem = num - top * TWOPOW32
 
   buf.writeUInt16BE(top, offset)
   buf.writeUInt32BE(rem, offset + 2)
@@ -25,7 +25,7 @@ exports.decode = function (buf, offset) {
   var top = buf.readUInt16BE(offset)
   var rem = buf.readUInt32BE(offset + 2)
 
-  return top * (UINT_32_MAX+1) + rem
+  return top * TWOPOW32 + rem
 }
 
 exports.encode.bytes = 6

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ exports.encode = function (num, buf, offset) {
   if (!buf) buf = new Buffer(6)
   if (!offset) offset = 0
 
-  var top = Math.floor(num / UINT_32_MAX)
-  var rem = num - top * UINT_32_MAX
+  var top = Math.floor(num / (UINT_32_MAX + 1))
+  var rem = num - top * (UINT_32_MAX + 1)
 
   buf.writeUInt16BE(top, offset)
   buf.writeUInt32BE(rem, offset + 2)
@@ -25,7 +25,7 @@ exports.decode = function (buf, offset) {
   var top = buf.readUInt16BE(offset)
   var rem = buf.readUInt32BE(offset + 2)
 
-  return top * UINT_32_MAX + rem
+  return top * (UINT_32_MAX+1) + rem
 }
 
 exports.encode.bytes = 6

--- a/test.js
+++ b/test.js
@@ -4,14 +4,22 @@ var tape = require('tape')
 tape('encode', function (t) {
   t.same(uint48be.encodingLength(42), 6)
   t.same(uint48be.encode(42), new Buffer([0, 0, 0, 0, 0, 42]))
-  t.same(uint48be.encode(42424242424242), new Buffer([0x26, 0x95, 0xa9, 0xe6, 0x70, 0x47]))
+  // according to bc
+  // obase=16
+  // 42424242424242
+  // 2695A9E649B2
+  t.same(uint48be.encode(42424242424242), new Buffer([0x26, 0x95, 0xa9, 0xe6, 0x49, 0xb2]))
   t.same(uint48be.encode.bytes, 6)
   t.end()
 })
 
 tape('decode', function (t) {
   t.same(uint48be.decode(new Buffer([0, 0, 0, 0, 0, 42])), 42)
-  t.same(uint48be.decode(new Buffer([0x26, 0x95, 0xa9, 0xe6, 0x70, 0x47])), 42424242424242)
+  // according to bc
+  // ibase=16
+  // 2695A9E67047
+  // 42424242434119
+  t.same(uint48be.decode(new Buffer([0x26, 0x95, 0xa9, 0xe6, 0x70, 0x47])), 42424242434119)
   t.same(uint48be.decode(new Buffer.from('ffffffffffff', 'hex')), Math.pow(2, 48) -1)
   t.same(uint48be.decode.bytes, 6)
   t.end()

--- a/test.js
+++ b/test.js
@@ -12,6 +12,7 @@ tape('encode', function (t) {
 tape('decode', function (t) {
   t.same(uint48be.decode(new Buffer([0, 0, 0, 0, 0, 42])), 42)
   t.same(uint48be.decode(new Buffer([0x26, 0x95, 0xa9, 0xe6, 0x70, 0x47])), 42424242424242)
+  t.same(uint48be.decode(new Buffer.from('ffffffffffff', 'hex')), Math.pow(2, 48) -1)
   t.same(uint48be.decode.bytes, 6)
   t.end()
 })


### PR DESCRIPTION
Hi mafintosh,

dividing/multiplying by MAX_UNT_32 actually is not correct. The factor has to be 2^32, that is one more than MAXINT.

For illustration, in  a 16bit word, you multiply the high byte with 256, not 0xFF (255)

```
0xffff = 65535
= 255 * 256 + 255
```